### PR TITLE
Fix load_all() for rprojroot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,16 +9,17 @@ Description: pkgload is simulates the process of installing a package
     and then attaching it. This is a key part of devtools as it allows you
     to rapidly iterate with a package.
 Imports:
-    withr,
+    bitops,
+    callr,
     methods,
-    rstudioapi,
     pkgbuild,
+    rstudioapi,
     roxygen2,
-    bitops
+    withr
 Suggests:
+    covr,
     Rcpp,
-    testthat,
-    covr
+    testthat
 Remotes:
     r-pkgs/pkgbuild
 License: GPL-3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,17 +9,16 @@ Description: pkgload is simulates the process of installing a package
     and then attaching it. This is a key part of devtools as it allows you
     to rapidly iterate with a package.
 Imports:
-    bitops,
-    callr,
+    withr,
     methods,
-    pkgbuild,
     rstudioapi,
+    pkgbuild,
     roxygen2,
-    withr
+    bitops
 Suggests:
-    covr,
     Rcpp,
-    testthat
+    testthat,
+    covr
 Remotes:
     r-pkgs/pkgbuild
 License: GPL-3

--- a/R/load.r
+++ b/R/load.r
@@ -127,7 +127,7 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
 
   # If installed version of package loaded, unload it
   if (is_loaded(pkg) && is.null(dev_meta(pkg$package))) {
-    unload(pkg)
+    unload(pkg, quiet = quiet)
   }
 
   # Unload dlls
@@ -135,7 +135,7 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
 
   if (reset) {
     clear_cache()
-    if (is_loaded(pkg)) unload(pkg)
+    if (is_loaded(pkg)) unload(pkg, quiet = quiet)
   }
 
   if (recompile)

--- a/R/load.r
+++ b/R/load.r
@@ -146,6 +146,11 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
   # Compile dll if it exists
   pkgbuild::compile_dll(pkg$path, quiet = quiet)
 
+  # If installed version of package loaded, unload it, again
+  # (needed for dependencies of pkgbuild)
+  if (is_loaded(pkg) && is.null(dev_meta(pkg$package))) {
+    unload(pkg, quiet = TRUE)
+  }
 
   # Set up the namespace environment ----------------------------------
   # This mimics the procedure in loadNamespace

--- a/R/load.r
+++ b/R/load.r
@@ -139,21 +139,18 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
     if (is_loaded(pkg)) unload(pkg, quiet = quiet)
   }
 
-  # Compile in new R session to make sure this doesn't load any new packages
-  # (e.g., rprojroot)
-  callr::r_vanilla(
-    function(pkg_path, recompile, quiet) {
-      if (recompile) {
-        pkgbuild::clean_dll(pkg_path)
-      }
+  if (recompile) {
+    pkgbuild::clean_dll(pkg$path)
+  }
 
-      # Compile dll if it exists
-      pkgbuild::compile_dll(pkg_path, quiet = quiet)
-    },
-    libpath = .libPaths(),
-    repos = getOption("repos"),
-    args = list(pkg_path = pkg$path, recompile = recompile, quiet = quiet)
-  )
+  # Compile dll if it exists
+  pkgbuild::compile_dll(pkg$path, quiet = quiet)
+
+  # If installed version of package loaded, unload it, again
+  # (needed for dependencies of pkgbuild)
+  if (is_loaded(pkg) && is.null(dev_meta(pkg$package))) {
+    unload(pkg, quiet = TRUE)
+  }
 
   # Set up the namespace environment ----------------------------------
   # This mimics the procedure in loadNamespace

--- a/R/load.r
+++ b/R/load.r
@@ -139,18 +139,21 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
     if (is_loaded(pkg)) unload(pkg, quiet = quiet)
   }
 
-  if (recompile) {
-    pkgbuild::clean_dll(pkg$path)
-  }
+  # Compile in new R session to make sure this doesn't load any new packages
+  # (e.g., rprojroot)
+  callr::r_vanilla(
+    function(pkg_path, recompile, quiet) {
+      if (recompile) {
+        pkgbuild::clean_dll(pkg_path)
+      }
 
-  # Compile dll if it exists
-  pkgbuild::compile_dll(pkg$path, quiet = quiet)
-
-  # If installed version of package loaded, unload it, again
-  # (needed for dependencies of pkgbuild)
-  if (is_loaded(pkg) && is.null(dev_meta(pkg$package))) {
-    unload(pkg, quiet = TRUE)
-  }
+      # Compile dll if it exists
+      pkgbuild::compile_dll(pkg_path, quiet = quiet)
+    },
+    libpath = .libPaths(),
+    repos = getOption("repos"),
+    args = list(pkg_path = pkg$path, recompile = recompile, quiet = quiet)
+  )
 
   # Set up the namespace environment ----------------------------------
   # This mimics the procedure in loadNamespace

--- a/R/load.r
+++ b/R/load.r
@@ -139,8 +139,9 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
     if (is_loaded(pkg)) unload(pkg, quiet = quiet)
   }
 
-  if (recompile)
+  if (recompile) {
     pkgbuild::clean_dll(pkg$path)
+  }
 
   # Compile dll if it exists
   pkgbuild::compile_dll(pkg$path, quiet = quiet)

--- a/R/load.r
+++ b/R/load.r
@@ -125,13 +125,14 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
     message("Invalid DESCRIPTION:\n", paste(msg, collapse = "\n"))
   }
 
-  # If installed version of package loaded, unload it
   if (is_loaded(pkg) && is.null(dev_meta(pkg$package))) {
+    # If installed version of package loaded, unload it
+    # (and also the DLLs)
     unload(pkg, quiet = quiet)
+  } else {
+    # Unload only DLLs
+    unload_dll(pkg)
   }
-
-  # Unload dlls
-  unload_dll(pkg)
 
   if (reset) {
     clear_cache()

--- a/R/unload.r
+++ b/R/unload.r
@@ -12,6 +12,7 @@
 #'
 #' @param pkg package description, can be path or package name.  See
 #'   \code{\link{as.package}} for more information
+#' @inheritParams load_all
 #'
 #' @examples
 #' \dontrun{
@@ -27,7 +28,7 @@
 #' unload(inst("ggplot2"))
 #' }
 #' @export
-unload <- function(pkg = ".") {
+unload <- function(pkg = ".", quiet = FALSE) {
 
   pkg <- as.package(pkg)
 
@@ -78,9 +79,11 @@ unload <- function(pkg = ".") {
   # loadedNamespaces() and unloadNamespace() often don't work here
   # because things can be in a weird state.
   if (!is.null(.getNamespace(pkg$package))) {
-    message("unloadNamespace(\"", pkg$package,
-      "\") not successful, probably because another loaded package depends on it.",
-      "Forcing unload. If you encounter problems, please restart R.")
+    if (!quiet) {
+      message("unloadNamespace(\"", pkg$package,
+        "\") not successful, probably because another loaded package depends on it. ",
+        "Forcing unload. If you encounter problems, please restart R.")
+    }
     unregister_namespace(pkg$package)
   }
 


### PR DESCRIPTION
which is imported by pkgbuild and reloaded after unload. Contains a few more tweaks.