### PR TITLE
`load_all()` gains a `recollate` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,11 +13,11 @@ Imports:
     methods,
     rstudioapi,
     pkgbuild,
-    roxygen2,
     bitops
 Suggests:
     Rcpp,
     testthat,
+    roxygen2,
     covr
 Remotes:
     r-pkgs/pkgbuild

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgload 0.0.0.9000
 
+* `load_all()` gains a `recollate` argument and roxygen2 is now a Suggested
+  rather than required dependency. (#4)
+
 * `dev_help()` now optionally takes a character vector of packages to
   search within.  This replaces `find_topic()`.
   

--- a/R/load.r
+++ b/R/load.r
@@ -68,6 +68,7 @@
 #'   If `FALSE`, export only the objects that are listed as exports
 #'   in the NAMESPACE file.
 #' @param quiet if `TRUE` suppresses output from this function.
+#' @param recollate if `TRUE`, run [roxygen2::update_collate()] before loading.
 #' @inheritParams as.package
 #' @keywords programming
 #' @examples
@@ -87,7 +88,7 @@
 #' }
 #' @export
 load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
-                     export_all = TRUE, quiet = FALSE) {
+                     export_all = TRUE, recollate = FALSE, quiet = FALSE) {
   pkg <- as.package(pkg)
 
   if (!quiet) message("Loading ", pkg$package)
@@ -101,9 +102,12 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
     on.exit(compiler::enableJIT(oldEnabled), TRUE)
   }
 
-  roxygen2::update_collate(pkg$path)
-  # Refresh the pkg structure with any updates to the Collate entry
-  # in the DESCRIPTION file
+  if (isTRUE(recollate)) {
+    check_suggested("roxygen2")
+    roxygen2::update_collate(pkg$path)
+    # Refresh the pkg structure with any updates to the Collate entry
+    # in the DESCRIPTION file
+  }
   pkg$collate <- as.package(pkg$path)$collate
 
   # Forcing all of the promises for the loaded namespace now will avoid lazy-load

--- a/man/load_all.Rd
+++ b/man/load_all.Rd
@@ -5,7 +5,7 @@
 \title{Load complete package.}
 \usage{
 load_all(pkg = ".", reset = TRUE, recompile = FALSE, export_all = TRUE,
-  quiet = FALSE)
+  recollate = FALSE, quiet = FALSE)
 }
 \arguments{
 \item{pkg}{package description, can be path or package name.  See
@@ -24,6 +24,8 @@ This is equivalent to running \code{\link[pkgbuild:clean_dll]{pkgbuild::clean_dl
 \item{export_all}{If \code{TRUE} (the default), export all objects.
 If \code{FALSE}, export only the objects that are listed as exports
 in the NAMESPACE file.}
+
+\item{recollate}{if \code{TRUE}, run \code{\link[roxygen2:update_collate]{roxygen2::update_collate()}} before loading.}
 
 \item{quiet}{if \code{TRUE} suppresses output from this function.}
 }

--- a/tests/testthat/test-load-collate.r
+++ b/tests/testthat/test-load-collate.r
@@ -38,7 +38,7 @@ test_that("DESCRIPTION Collate field, with latest @includes, is recognised by lo
   on.exit(unlink(test_pkg, recursive = TRUE))
 
   expect_output(
-    expect_message(load_all(test_pkg), "Loading testCollateOrder"),
+    expect_message(load_all(test_pkg, recollate = TRUE), "Loading testCollateOrder"),
     "Updating collate directive"
   )
 


### PR DESCRIPTION
This makes roxygen2 is now a Suggested rather than required dependency.

Fixes #4